### PR TITLE
Updated JQuery selector for new Yelp layout

### DIFF
--- a/yell
+++ b/yell
@@ -44,7 +44,7 @@ function load(n) {
                 id: $(this).attr('data-review-id')
             });
         });
-        if ($('#pager_page_next').length) {
+        if ($('.next.pagination-links_anchor').length) {
             load(n + 10);
         } else {
             done(reviews);


### PR DESCRIPTION
The old JQuery selector `$('#pager_page_next')` no longer appears on the yelp details page. Instead we should use the new `$('.next.pagination-links_anchor')` selector to see if there are more reviews.

Thanks for the work you put into this, its come in handy!
