### PR TITLE
Added photo downloading functionality.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.idea
+node_modules
+photos
+yelp.html
+yelp.json

--- a/README.md
+++ b/README.md
@@ -41,3 +41,12 @@ That end bit - the random letters after the `=`, is your userid.
 
     npm install yell
     yell YOUR_YELP_USER_ID
+
+### Retrieving Photos
+
+If you wish to retrieve your photos as well as your reviews, simple add `-photos` to the end of the call.
+
+    npm install yell
+    yell YOUR_YELP_USER_ID -photos
+
+Photos will be stored in a `photos` directory, grouped by the location, then photo ID i.e. `photos/Lyle's Cafè Shoreditch/d4E4Wh7cwjxRpLflGNwJIA.jpg`.

--- a/package.json
+++ b/package.json
@@ -15,8 +15,9 @@
   },
   "dependencies": {
     "cheerio": "0.4.2",
-    "underscore": "1.3.0",
-    "get": "1.1.2"
+    "get": "1.1.2",
+    "request": "^2.72.0",
+    "underscore": "1.3.0"
   },
   "bin": {
     "yell": "yell"

--- a/yell
+++ b/yell
@@ -4,11 +4,15 @@ var cheerio = require('cheerio'),
     fs = require('fs'),
     path = require('path'),
     _ = require('underscore'),
-    get = require('get');
+    get = require('get'),
+    request = require('request');
 
 var userid = process.argv[2],
+    shouldDownloadPhotos = (process.argv[3] == '-photos'),
     itr = 0,
-    reviews = [];
+    finishCount = 0,
+    reviews = [],
+    photos = [];
 
 if (!userid) throw "Please specify a Yelp userid as the only argument to this " +
         "utility. Find it by going to your profile page and looking in the URL.";
@@ -19,10 +23,20 @@ function yurl(start) {
         userid + '&rec_pagestart=' + start;
 }
 
-function done(reviews) {
+function ypurl(start) {
+    console.log('fetching photo data starting with ' + start);
+    return 'http://www.yelp.com/user_local_photos?userid=' +
+        userid + '&start=' + start;
+}
+
+function rpurl(id) {
+    return 'https://s3-media3.fl.yelpcdn.com/bphoto/' + id + '/o.jpg';
+}
+
+function finishedReviews() {
     fs.writeFileSync('yelp.json', JSON.stringify(reviews), 'utf8');
     draw(reviews);
-    console.log('\nFinished! Find in this directory:\n- yelp.html, a hreview-formatted HTML version\n- yelp.json: raw JSON data.');
+    showFinishedMessage();
 }
 
 function draw(r) {
@@ -31,7 +45,7 @@ function draw(r) {
     }), 'utf8');
 }
 
-function load(n) {
+function loadReviews(n) {
     get({ uri: yurl(n) }).asString(function(err, str) {
         if (err) throw err;
 
@@ -45,11 +59,83 @@ function load(n) {
             });
         });
         if ($('.next.pagination-links_anchor').length) {
-            load(n + 10);
+            loadReviews(n + 10);
         } else {
-            done(reviews);
+            finishedReviews();
         }
     });
 }
 
-load(0);
+function loadPhotos(n) {
+    get({ uri: ypurl(n) }).asString(function(err, str) {
+        if (err) throw err;
+
+        var $ = cheerio.load(str);
+        $('ul.photo-box-grid li').each(function(i, elem) {
+            var id = $(elem).attr('data-photo-id');
+
+            photos.push({
+                location: $(this).children('div.photo-box-overlay_caption').text(),
+                url: rpurl(id),
+                id: id
+            });
+        });
+        if ($('.next.pagination-links_anchor').length) {
+            loadPhotos(n + 30);
+        } else {
+            downloadPhotos();
+        }
+    });
+}
+
+function downloadPhotos() {
+    makeDir('photos');
+
+    downloadPhoto(0);
+}
+
+function downloadPhoto(id) {
+    var photo = photos[id];
+
+    makeDir('photos/'+photo.location);
+    console.log('Downloading photo ' + (id+1) + ' of ' + photos.length);
+    request(photo.url).pipe(
+        fs.createWriteStream('photos/' + photo.location + '/' + photo.id + '.jpg')
+    ).on(
+        'close',
+        function() {
+            if( id < (photos.length - 1) ) {
+                downloadPhoto(id + 1);
+            } else {
+                showFinishedMessage();
+            }
+    });
+}
+
+function makeDir(path) {
+    try {
+        fs.mkdirSync(path);
+    } catch(e) {
+        // Silently continue
+    }
+}
+
+function showFinishedMessage() {
+    finishCount++;
+    var message = '\nFinished! Find in this directory:\n- yelp.html, a hreview-formatted HTML version\n- yelp.json: raw JSON data.';
+    var target = 1;
+
+    if(shouldDownloadPhotos) {
+        message += '\n- photos/: photos from yelp account';
+        target = 2;
+    }
+
+    if(finishCount == target)
+        console.log(message);
+}
+
+loadReviews(0);
+
+if(shouldDownloadPhotos){
+    loadPhotos(0);
+}


### PR DESCRIPTION
Added the ability for a user to also download all of the photos uploaded by a user. They simply need to all the `-photos` flag i.e.:

```bash
yell YOUR_YELP_USER_ID -photos
```

Photos are stored in the `photos` directory, by location and then, ID.

### Changes
* Added `-photos` flag
* Renamed and refactored some existing functions
* Scrapes photos page for photo IDs and location details
* Downloads photos one after the other
  * This is so we can reliably tell when all photos have finished downloading, and can give more helpful feedback to the user.
* Updated README to include details of Photos file

### Testing
Tested on an account with 248 photos.
Initially tried asynchronous but with such a large number of downloads the script became unresponsive. Seemed more prudent to download one after another.

These changes still product JSON and HTML as expected.

### Notes
I added request - I know you wrote node-get, but I couldn't get it to do the downloading (or I didn't understand how to get it to). If you know a better way of doing this using node-get I'll happily rewrite it 👍 