### PR TITLE
FIX: Locations can be interperated as directories

### DIFF
--- a/yell
+++ b/yell
@@ -72,10 +72,13 @@ function loadPhotos(n) {
 
         var $ = cheerio.load(str);
         $('ul.photo-box-grid li').each(function(i, elem) {
-            var id = $(elem).attr('data-photo-id');
+            var id = $(elem).attr('data-photo-id'),
+                location_name = $(this).children('div.photo-box-overlay_caption').text();
+
+            location_name = location_name.replace(/[\\|/]/g, '_');
 
             photos.push({
-                location: $(this).children('div.photo-box-overlay_caption').text(),
+                location: location_name,
                 url: rpurl(id),
                 id: id
             });


### PR DESCRIPTION
### Fixes #10 - Locations containing `/` are treated as directories

Sometimes, if a location's name contains a `/` i.e.

> The Harry Potter Shop at Platform 9 3/4

When saving an image we can mistakenly try and save them within a sub-folder 4:

```
photos/The Harry Potter Shop at Platform 9 3/4/image.jpg
```

To fix this we now replace `/` with `_` so the above becomes:

```
photos/The Harry Potter Shop at Platform 9 3_4/image.jpg
```
